### PR TITLE
Split cl-markdown feature into its own system

### DIFF
--- a/cl-markdown.lisp
+++ b/cl-markdown.lisp
@@ -1,0 +1,17 @@
+(in-package #:spinneret)
+
+(defun parse-as-markdown (string)
+  "Expand STRING as markdown only if it contains markdown."
+  (declare (string string))
+  (let ((expansion
+          (with-output-to-string (s)
+            (let (markdown:*parse-active-functions*
+                  markdown:*render-active-functions*)
+              (markdown:markdown string
+                                 :stream s
+                                 :format :html)))))
+    (if (search string expansion)
+        string
+        (if (find #\Newline string)
+            expansion
+            (trim-ends "<p>" expansion "</p>")))))

--- a/compile.lisp
+++ b/compile.lisp
@@ -136,21 +136,11 @@ are all the following key-value pairs, and the body is what remains."
                      attr tag))
     attrs))
 
+(declaim (notinline parse-as-markdown))
 (defun parse-as-markdown (string)
-  "Expand STRING as markdown only if it contains markdown."
-  (declare (string string))
-  (let ((expansion
-          (with-output-to-string (s)
-            (let (markdown:*parse-active-functions*
-                  markdown:*render-active-functions*)
-              (markdown:markdown string
-                                 :stream s
-                                 :format :html)))))
-    (if (search string expansion)
-        string
-        (if (find #\Newline string)
-            expansion
-            (trim-ends "<p>" expansion "</p>")))))
+  "Placeholder, load spinneret.cl-markdown system if you want to expand
+  markdown."
+  string)
 
 (defun trim-ends (prefix string suffix)
   (declare (string prefix string suffix))

--- a/spinneret.asd
+++ b/spinneret.asd
@@ -7,8 +7,7 @@
   :license "MIT"
   :in-order-to ((asdf:test-op (asdf:test-op #:spinneret-tests)))
   :serial t
-  :depends-on (#:cl-markdown
-               #:parenscript
+  :depends-on (#:parenscript
                #:alexandria
                #:cl-ppcre)
   :components ((:file "package")

--- a/spinneret.cl-markdown.asd
+++ b/spinneret.cl-markdown.asd
@@ -1,0 +1,11 @@
+(in-package #:asdf-user)
+
+(asdf:defsystem #:spinneret.cl-markdown
+  :description "Integration with cl-markdown"
+  :version "2.0"
+  :author "Paul M. Rodriguez <pmr@ruricolist.com>"
+  :license "MIT"
+  :serial t
+  :depends-on (#:cl-markdown
+               #:spinneret)
+  :components ((:file "cl-markdown")))


### PR DESCRIPTION
The main reason is that cl-markdown and [markdown.cl](https://github.com/orthecreedence/markdown.cl) use the same package nickname, markdown. I think the md functionality is a nice to have, but it chosing spinneret shouldn't force you to use a particular markdown lib.