### PR TITLE
Remove deftemplate from exported symbols

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -6,7 +6,7 @@
            #:*html* #:*html-fill-column* #:*html-min-room*
            #:*html-lang* #:*html-charset*
            #:*html-path*
-           #:deftemplate #:do-elements
+           #:do-elements
            #:deftag
            #:*unvalidated-attribute-prefixes*)
   (:shadowing-import-from :alexandria :switch))


### PR DESCRIPTION
The functionality was removed on e2cbe0e22dd2e9e6c50daf5d7081fc7a02e64d1c

Maybe the readme about parenscript limitations should be updated as well?