### PR TITLE
Use SYNONYM-STREAM for *HTML*

### DIFF
--- a/spinneret.lisp
+++ b/spinneret.lisp
@@ -6,7 +6,7 @@
 
 (declaim (stream *html*))
 
-(defparameter *html* *standard-output*
+(defparameter *html* (make-synonym-stream '*standard-output*)
   "Output stream for HTML generation.")
 
 (defvar *html-path* nil


### PR DESCRIPTION
By using a synonym-stream, *HTML* defaults to the value
that *STANDARD-OUTPUT* is bound at the moment *HTML* is referenced.
Otherwise *HTML* will be bound the value of *STANDARD-OUTPUT* at
load-time. A common problem with this behavior is when spinneret is
loaded using the :silent option of quickload, ie. (ql:quickload
:spinneret :silent t). When this happens spinneret will not print any
output as *HTML* is bound to BROADCAST-STREAM associated with zero streams.

For more information see the following [lisptip](http://lisptips.com/post/127524780849/when-a-synonym-stream-is-useful)