### PR TITLE
Remove unnecessary feature expression

### DIFF
--- a/functions.lisp
+++ b/functions.lisp
@@ -1,7 +1,7 @@
 (in-package #:spinneret)
 
 (defpackage #:spinneret.tag
-  #+ccl (:use))
+ (:use))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defparameter *tags-pkg* (find-package :spinneret.tag))


### PR DESCRIPTION
We want an empty the package SPINNERET.TAG to use no packages, as the
default is implementation dependent we should always supply a use option