### PR TITLE
Fixed spinneret/cl-markdown loading from ASDF package inferred systems.

### DIFF
--- a/cl-markdown.lisp
+++ b/cl-markdown.lisp
@@ -1,6 +1,12 @@
-(in-package #:spinneret)
+;; We define this package to make ASDF package-inferred
+;; systems happy
+(defpackage #:spinneret/cl-markdown
+  (:use #:cl))
+(in-package #:spinneret/cl-markdown)
 
-(defun parse-as-markdown (string)
+;; Here we redefine a function inside of the main
+;; package, to change it's behavior
+(defun spinneret::parse-as-markdown (string)
   "Expand STRING as markdown only if it contains markdown."
   (declare (string string))
   (let ((expansion
@@ -14,4 +20,4 @@
         string
         (if (find #\Newline string)
             expansion
-            (trim-ends "<p>" expansion "</p>")))))
+            (spinneret::trim-ends "<p>" expansion "</p>")))))


### PR DESCRIPTION
Previously, some lisps like SBCL raise this error:

    debugger invoked on a SB-KERNEL:SIMPLE-PACKAGE-ERROR in thread
    #<THREAD "main thread" RUNNING {10005505B3}>:
      The name "SPINNERET/CL-MARKDOWN" does not designate any package.

    Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

when you did:

    (:import-from #:spinneret/cl-markdown)

Cause of this behavior, it that nonetheless ASDF has loaded
spinneret/cl-markdown system, the Lisp itself was unable to find
a corresponding package.

You might suppose that: "Hey you can just add a "spinneret/cl-markdown"
to your system's ASD file!" But this does not work for some reason
even when you specify :serial t in the system's definition.