### PR TITLE
Raw content is now processed as a "preformatted"

### DIFF
--- a/run.lisp
+++ b/run.lisp
@@ -370,8 +370,10 @@ able to use directives like ~c, ~d, ~{~} &c."
     ,@args))
 
 (defun write-raw (&rest args)
-  `(prog1 nil ,@(loop for arg in args
-                      collect `(fill-text ,arg t))))
+  `(let ((*pre* t))
+     ,@(loop for arg in args
+             collect `(fill-text ,arg t))
+     nil))
 
 (-> heading-depth () (integer 1 6))
 (defun heading-depth ()

--- a/tests.lisp
+++ b/tests.lisp
@@ -520,3 +520,10 @@
                         (spinneret:with-html-string
                           (:p "hello")
                           (:span "world"))))))
+
+
+(test raw-shouldnt-pretty-print-its-content
+  (is (visually-equal
+       "Very very very very very very very very very very very very very very very very very very very very very very very very long line"
+       (with-html-string
+         (:raw "Very very very very very very very very very very very very very very very very very very very very very very very very long line")))))


### PR DESCRIPTION
This fixes issues intruduced by reformatting :raw tag's content
when *print-pretty* is `t`.