### PR TITLE
Escape single and double quote when serializing text.

### DIFF
--- a/syntax.lisp
+++ b/syntax.lisp
@@ -43,7 +43,9 @@
     (#\& "&amp;")
     (#.no-break-space "&nbsp;")
     (#\< "&lt;")
-    (#\> "&gt")))
+    (#\> "&gt")
+    (#\" "&quot")
+    (#\' "&#39")))
 
 (defun escape-string (string)
   (escape-with-table string #'escape-string-char))


### PR DESCRIPTION
Not escaping quotes can lead to broken text, e.g., when rendering Spinneret-generated pages with WebKitGTK. We've encountered it in [Nyxt, when generating internal pages with Spinneret](https://github.com/atlas-engineer/nyxt/issues/2011).