### PR TITLE
Fix (style-)warnings and sbcl-notes

### DIFF
--- a/run.lisp
+++ b/run.lisp
@@ -41,6 +41,9 @@
   (when *pending-space*
     (setf *pending-space* nil)))
 
+(serapeum:defconstructor escaped-string
+  (value string))
+
 (defmacro catch-output (arg &environment env)
   (labels ((print-escaped (x)
              `(html ,(escaped-string (escape-string x))))
@@ -76,9 +79,6 @@
   (:method :around ((nada null))
     (values))
   (:documentation "Handle writing OBJECT as HTML (for side-effects only)."))
-
-(serapeum:defconstructor escaped-string
-  (value string))
 
 (define-compiler-macro html (object)
   `(locally (declare (notinline html))

--- a/stream.lisp
+++ b/stream.lisp
@@ -4,6 +4,10 @@
   (:method ((stream stream))
     stream))
 
+(defgeneric html-stream-column (stream)
+  (:method ((x stream))
+    0))
+
 (defclass html-stream (fundamental-character-output-stream)
   ((col :type (integer 0 *) :initform 0
         :reader html-stream-column
@@ -36,10 +40,6 @@
 (defgeneric elastic-newline (stream)
   (:method ((x t))
     (values)))
-
-(defgeneric html-stream-column (stream)
-  (:method ((x stream))
-    0))
 
 (defun newline (&optional s)
   (when *print-pretty*

--- a/tags.lisp
+++ b/tags.lisp
@@ -96,7 +96,7 @@
       :sup :table :tbody :td :template :textarea :tfoot :th :thead :time :title :tr
       :track :u :ul :var :video :wbr))
 
-(-> valid? (keyword) (or keyword null))
+(-> valid? (keyword) (values (or keyword null) &optional))
 (defun valid? (element)
   (or (car (memq element *html5-elements*))
       (valid-custom-element-name? element)))


### PR DESCRIPTION
1 style-warning:
- Proclaiming `inline`, but calls to it were previously compiled

1 warning:
- redefining in `defgeneric`

2 sbcl-compiler-notes:
- Type assertion too complex to check
- can't open-code test of unknown type