### PR TITLE
Defpackage: only uninterned symbols; stop to :use packages

### DIFF
--- a/compile.lisp
+++ b/compile.lisp
@@ -57,7 +57,7 @@
   "Dissect a tag like `:div.class#id' into the tag itself and a plist
 of attributes."
   (destructuring-bind (tag . parts)
-      (ppcre:split "([.#])" (string-downcase tag) :with-registers-p t)
+      (split "([.#])" (string-downcase tag) :with-registers-p t)
     (values (make-keyword (string-upcase tag))
             (sublis '(("." . :class)
                       ("#" . :id))

--- a/functions.lisp
+++ b/functions.lisp
@@ -73,7 +73,7 @@
 
 ;;; The auxiliary functions are block-compiled for speed.
 
-(serapeum:local*
+(local*
   (declaim (optimize (speed 3) (safety 0) (debug 0)
                      (compilation-speed 0)))
 

--- a/package.lisp
+++ b/package.lisp
@@ -54,7 +54,21 @@
                 #:-> #:with-thunk
                 #:and-let* #:op #:string-prefix-p
                 #:memq
+                #:string$=
+                #:string^=
+                #:escape
+                #:defconst
+                #:defconstructor
+                #:string-replace-all
+                #:local*
+                #:fbind
+                #:fbind*
+                #:bound-value
+                #:defmethods
+                #:eval-if-constant
                 #:parse-leading-keywords)
+  (:import-from #:cl-ppcre
+                #:split)
   (:import-from #:trivia
                 #:match)
   (:import-from #:global-vars

--- a/package.lisp
+++ b/package.lisp
@@ -1,8 +1,7 @@
 ;;;; package.lisp
 
 (defpackage #:spinneret
-  (:use #:cl #:parenscript #:alexandria
-        #:trivial-gray-streams)
+  (:use #:cl)
   (:export #:with-html #:with-html-string #:html
            #:*html*
            #:*html-lang* #:*html-charset*
@@ -19,7 +18,34 @@
            #:no-such-tag
            #:*suppress-inserted-spaces*
            #:interpret-html-tree)
-  (:shadowing-import-from :alexandria :switch)
+  (:import-from #:parenscript
+                #:concat-constant-strings ;; unexported function
+                #:define-ps-symbol-macro
+                #:defpsmacro
+                #:with-ps-gensyms)
+  (:import-from #:trivial-gray-streams
+                #:fundamental-character-output-stream
+                #:stream-write-char #:stream-write-string
+                #:stream-terpri
+                #:stream-fresh-line
+                #:stream-finish-output
+                #:stream-force-output
+                #:stream-advance-to-column
+                #:stream-start-line-p)
+  (:import-from #:alexandria
+                #:array-index
+                #:clamp
+                #:string-designator
+                #:make-keyword
+                #:parse-body #:parse-ordinary-lambda-list
+                #:with-gensyms #:with-unique-names
+                #:remove-from-plist
+                #:starts-with-subseq
+                #:when-let #:if-let
+                #:assoc-value
+                #:disjoin
+                #:doplist
+                #:once-only)
   (:import-from
    :serapeum
    :fmt :eif :econd

--- a/package.lisp
+++ b/package.lisp
@@ -46,18 +46,19 @@
                 #:disjoin
                 #:doplist
                 #:once-only)
-  (:import-from
-   :serapeum
-   :fmt :eif :econd
-   :define-do-macro :defconst
-   :nlet :nix :assure
-   :find-keyword
-   :-> :with-thunk
-   :and-let* :op :string-prefix-p
-   :memq
-   :parse-leading-keywords)
-  (:import-from :trivia :match)
-  (:import-from :global-vars :define-global-parameter))
+  (:import-from #:serapeum
+                #:fmt #:eif #:econd
+                #:define-do-macro #:defconst
+                #:nlet #:nix #:assure
+                #:find-keyword
+                #:-> #:with-thunk
+                #:and-let* #:op #:string-prefix-p
+                #:memq
+                #:parse-leading-keywords)
+  (:import-from #:trivia
+                #:match)
+  (:import-from #:global-vars
+                #:define-global-parameter))
 
 (defpackage #:spinneret-user
   (:use #:cl #:parenscript #:spinneret))

--- a/ps.lisp
+++ b/ps.lisp
@@ -97,13 +97,13 @@
 (defpsmacro comment (text safe?)
   (declare (ignore safe?))
   `(stringify
-    ,(ps::concat-constant-strings
+    ,(concat-constant-strings
       (list "<!-- " text " -->"))))
 
 (defpsmacro cdata (text safe?)
   (declare (ignore safe?))
   `(stringify
-    ,(ps::concat-constant-strings
+    ,(concat-constant-strings
       (list cdata-start text cdata-end))))
 
 (defpsmacro format-text (formatter &rest args)
@@ -120,7 +120,7 @@
 
 (defpsmacro join-tokens (&rest classes)
   `(stringify
-    ,@(ps::concat-constant-strings
+    ,@(concat-constant-strings
        (intersperse " "
                     (remove-duplicates (remove nil classes)
                                        :test #'equal)))))

--- a/special.lisp
+++ b/special.lisp
@@ -19,7 +19,7 @@
 (defvar *indent*)
 
 (defun get-indent ()
-  (or (serapeum:bound-value '*indent*)
+  (or (bound-value '*indent*)
       *depth*))
 
 (defvar *pre* nil)

--- a/stream.lisp
+++ b/stream.lisp
@@ -45,8 +45,7 @@
   (when *print-pretty*
     (terpri s)))
 
-(serapeum:defmethods html-stream (s col line last-char base-stream
-                                    elastic-newline)
+(defmethods html-stream (s col line last-char base-stream elastic-newline)
   (:method ensure-html-stream (s)
     s)
 

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -31,7 +31,7 @@
 (defun needs-quotes? (string)
   (declare (string string))
   (or (some #'must-quote? string)
-      (serapeum:string$= "/" string)))
+      (string$= "/" string)))
 
 ;; See 8.3.
 ;; http://www.w3.org/TR/html5/the-end.html#serializing-html-fragments
@@ -65,17 +65,17 @@
                          (#\' "&#39;")))))
 
 (defun escape-to-stream (string table stream)
-  (serapeum:escape string table :stream stream))
+  (escape string table :stream stream))
 
 (defun escape-with-table (string table)
-  (serapeum:escape string table))
+  (escape string table))
 
 ;; See 8.1.5
 ;; http://www.w3.org/TR/html5/syntax.html#cdata-sections
 
-(serapeum:defconst cdata-start "<![CDATA[")
+(defconst cdata-start "<![CDATA[")
 
-(serapeum:defconst cdata-end "]]>")
+(defconst cdata-end "]]>")
 
 (defun escape-cdata (text)
   (remove-substring text cdata-end))
@@ -87,4 +87,4 @@
   (remove-substring (string-trim ">-" text) "--"))
 
 (defun remove-substring (string substring)
-  (serapeum:string-replace-all substring string ""))
+  (string-replace-all substring string ""))


### PR DESCRIPTION
1. [Fix: `:import-from` instead of `:use` packages](https://github.com/ruricolist/spinneret/commit/a9c55e0fcce60f9e76dbd7c8694f0b2e49d1cf54)
-> avoid potential name "collisions"
2. [Fix: utilize uninterned symbols in import clauses](https://github.com/ruricolist/spinneret/commit/5cf2b866981baa22d5080e8e0881eb9b02f44bf5)
-> avoid symbol internalization in `keyword` package
3. [Style: `:import-from` qualified external symbols](https://github.com/ruricolist/spinneret/commit/33a86023818029a6fc513ec60efe4b16d25317ec)
-> transparent symbol dependencies
-> remove package qualifiers