### PR TITLE
package: Export escape-string.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -17,7 +17,8 @@
            #:spinneret-error
            #:no-such-tag
            #:*suppress-inserted-spaces*
-           #:interpret-html-tree)
+           #:interpret-html-tree
+           #:escape-string)
   (:import-from #:parenscript
                 #:concat-constant-strings ;; unexported function
                 #:define-ps-symbol-macro


### PR DESCRIPTION
This exports `escape-string`, because it's a useful thing when dealing with HTML, and is a stable enough part of Spinneret API (added in 2012, according to `git blame`) to be safely exported :)

@ruricolist, looks good to you?