### PR TITLE
Fix "Undefined operator KEYWORD-SET in form ..." error on LispWorks

### DIFF
--- a/tags.lisp
+++ b/tags.lisp
@@ -9,10 +9,11 @@
           paragraph?
           preformatted?))
 
-(defmacro keyword-set (&body body)
-  (assert (every #'keywordp body))
-  ;; Return a literal hash table.
-  (set-hash-table body :test 'eq))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defmacro keyword-set (&body body)
+    (assert (every #'keywordp body))
+    ;; Return a literal hash table.
+    (set-hash-table body :test 'eq)))
 
 (define-global-parameter *void-elements*
     (keyword-set


### PR DESCRIPTION
I've got this compilation error in LispWorks on the latest Spinneret from the GitHub:

```
Undefined operator KEYWORD-SET in form (KEYWORD-SET :!DOCTYPE :AREA :BASE :BR :COL :COMMAND :EMBED :HR :IMG :INPUT :KEYGEN :LINK :META :PARAM :SOURCE :TRACK :WBR).
```

The problem is recent changes in tags.lisp file. `KEYWORD-SET` macro was introduces and is used in the same file. But [standard says](http://www.lispworks.com/documentation/lw70/CLHS/Body/03_bc.htm) that compiler might evaluate all toplevel forms only after the whole file compilation.

I've wrapped the macro definition with `EVAL-WHEN` block and now LispWorks is able to compile file.