### PR TITLE
Add a macro to rebind the path, with-html-path.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -6,6 +6,7 @@
            #:*html*
            #:*html-lang* #:*html-charset*
            #:get-html-path
+           #:with-html-path
            #:do-elements
            #:deftag
            #:*unvalidated-attribute-prefixes*

--- a/spinneret.lisp
+++ b/spinneret.lisp
@@ -18,6 +18,12 @@
 This is necessary because *HTML-PATH* itself is stack-allocated."
   (copy-list *html-path*))
 
+(defmacro with-html-path (value &body body)
+  "Modify *HTML-PATH* to VALUE in the scope of BODY.
+Useful to override the behavior of tags (like :H*) dependent on *HTML-PATH*."
+  `(let ((*html-path* ,value))
+     ,@body))
+
 (defmacro with-html (&body body &environment env)
   "Interpret BODY as HTML. Consult README.txt for the syntax."
   `(let ((*html* (ensure-html-stream *html*)))


### PR DESCRIPTION
This adds a new macro, `with-html-path`, that let-binds `*html-path*` so that the behavior of smart tags, like `:h*` can be influenced from outside them without modifying unexported `*html-path*` directly.

The use-case is splitting Spinneret-generated code into several functions and setting the section depth independently in each of these functions. Given that we often split Spinneret code into functions in Nyxt, this one is quite critical to not depend on unexported APIs of Spinneret.