### PR TITLE
fix: don't insert leading newline when pretty printing pre tags

### DIFF
--- a/run.lisp
+++ b/run.lisp
@@ -330,7 +330,7 @@ make reasonable decisions about line wrapping.")
             string))))
 
 (defun format-text (control-string &rest args)
-  (when *print-pretty*
+  (when (and *print-pretty* (not *pre*))
     (terpri *html*))
   (fill-text (format nil "~?" control-string args) t)
   (values))

--- a/tests.lisp
+++ b/tests.lisp
@@ -624,6 +624,13 @@ verbatim line two")
 bar</pre>"
     (with-html-string (:pre "foo" #\Newline "b" "a" "r")))))
 
+(test pre-no-spaces-format
+  (is
+   (visually-equal
+    "<pre>foo
+bar</pre>"
+    (with-html-string (:pre ("foo ~A~A~A~A" #\Newline "b" "a" "r"))))))
+
 (test pre-code
   (let ((*print-pretty* t))
     (is


### PR DESCRIPTION
When outputting `pre` elements don't insert extra newlines as that effects the way the content of the `pre` is displayed.

fixes #70