### PR TITLE
Add `:media` attribute to `:meta`.

### DIFF
--- a/tags.lisp
+++ b/tags.lisp
@@ -231,7 +231,7 @@
        (:link :href :rel :hreflang :media :type :sizes :integrity :crossorigin :referrerpolicy)
        (:map :name)
        (:menu :type :label)
-       (:meta :name :content :http-equiv :charset :property)
+       (:meta :name :content :http-equiv :charset :property :media)
        (:meter :value :min :low :high :max :optimum)
        (:object :data :type :height :width :usemap :name :form)
        (:ol :start :reversed :type)


### PR DESCRIPTION
Hi! I've been hacking on my personal website and tried to add [theme-dependent browser bar color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color). But then, Spinneret doesn't allow `media` attribute they suggest there, so here's a small fix for `media` attribute in `<meta>` tag 😉 