### PR TITLE
Add more attributes for `head` and `html` tags.

### DIFF
--- a/tags.lisp
+++ b/tags.lisp
@@ -212,7 +212,8 @@
        (:fieldset :name :disabled :form)
        (:form :action :method :enctype :name :accept-charset
          :novalidate :target :autocomplete)
-       (:html :manifest)
+       (:html :manifest :version :xmlns :prefix)
+       (:head :prefix :profile)
        (:iframe :src :srcdoc :name :width :height :sandbox :seamless :allowfullscreen
          :allowpaymentrequest :allow :frameborder :csp :fetchpriority :loading
          :referrerpolicy)


### PR DESCRIPTION
Continuing to SEO-optimize my website, I've digged into OpenGraph protocol and found that it uses non-standard `prefix` attribute for `html` and `head` tags (see the examples on the [OpenGraph website](https://ogp.me/)).

And then, MDN has a listing of [additional attributes for `html`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html), including `xmlns`, `version`, and `manifest`.

I've added all of them here.