### PR TITLE
Parenscript fixes

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -26,7 +26,10 @@
                 #:concat-constant-strings ;; unexported function
                 #:define-ps-symbol-macro
                 #:defpsmacro
-                #:with-ps-gensyms)
+                #:with-ps-gensyms
+                #:stringify
+                #:chain
+                #:@)
   (:import-from #:trivial-gray-streams
                 #:fundamental-character-output-stream
                 #:stream-write-char #:stream-write-string

--- a/package.lisp
+++ b/package.lisp
@@ -29,7 +29,8 @@
                 #:with-ps-gensyms
                 #:stringify
                 #:chain
-                #:@)
+                #:@
+                #:for-in)
   (:import-from #:trivial-gray-streams
                 #:fundamental-character-output-stream
                 #:stream-write-char #:stream-write-string

--- a/ps.lisp
+++ b/ps.lisp
@@ -83,7 +83,11 @@
                     (ch *html*
                         (set-attribute ,attr
                                        (stringify (@ ,attrs ,attr))))))))
-      (t `(ch *html* (set-attribute ,attr ,sval))))))
+      (t (with-ps-gensyms (actual-val)
+           `(let ((,actual-val ,val))
+              (if ,actual-val
+                  (ch *html* (set-attribute ,attr (stringify ,actual-val)))
+                  (ch *html* (remove-attribute ,attr)))))))))
 
 (defun event? (attr)
   (starts-with-subseq "on" (string attr)))


### PR DESCRIPTION
This

- Imports a few missing `parenscript` symbols into the `spinneret` package.
- Adjusts the Parenscript attribute-setting logic such that passing null as an attribute value omits it from the generated document entirely, matching the behavior from the Lisp implementation.