### PR TITLE
Fixes bug when outputting data-* elements in Parenscript version.

### DIFF
--- a/ps.lisp
+++ b/ps.lisp
@@ -81,7 +81,7 @@
          ;; Other special cases for IE.
          `(setf (@ *html* ,attr) ,sval))
         ((data-attr? attr)
-         `(setf (@ *html* dataset ,(data-attr-prop attr)) ,sval))
+         `(setf (@ *html* dataset ,(parenscript::encode-js-identifier (data-attr-prop attr))) ,sval))
         ((string-equal attr "attrs")
          (with-ps-gensyms (attrs attr)
            `(let ((,attrs ,val))


### PR DESCRIPTION
When trying to make a Bootstrap toast using Parenscript and Spinneret/ps, I ran into an error where Firefox kept complaining about how the data-bs-dismiss property was being added. After a conversation with Grok to figure out where in the generated code the issue was, I found that the dataset property expects a JavaScript-style identifier, which the browser converts to the dashed version itself. I used one of the Parenscript internal functions as a quick fix.