### PR TITLE
Add :as to :link's permitted attributes

### DIFF
--- a/tags.lisp
+++ b/tags.lisp
@@ -269,7 +269,7 @@
       (:keygen :challenge :keytype :autofocus :name :disabled :form)
       (:label :for :form)
       (:li :type :value)
-      (:link :href :rel :hreflang :media :type :sizes :integrity :crossorigin :referrerpolicy)
+      (:link :href :rel :hreflang :media :type :sizes :integrity :crossorigin :referrerpolicy :as)
       (:map :name)
       (:menu :type :label)
       (:meta :name :content :http-equiv :charset :property :media)


### PR DESCRIPTION
cf https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#as