### PR TITLE
doc: document *always-quote*, its compile-time-only behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
         - [`*html-path*`](#html-path)
     - [`deftag`](#deftag)
     - [Parenscript](#parenscript)
+    - [Attribute quoting](#attribute-quoting)
     - [Validation](#validation)
 
 <!-- markdown-toc end -->
@@ -534,6 +535,55 @@ To use Parenscript in Spinneret, remember to wrap the `ps` macro with `:raw`, ot
   (:div :onclick (:raw (ps (alert "Hello")))))
 "<div onclick=\"alert('Hello');\"></div>"
 ```
+
+## Attribute quoting
+
+By default, Spinneret only quotes an attribute value when the string it's
+given requires it per the HTML5 spec — values containing whitespace or one
+of `" ' \` = < > /`. This keeps ordinary output compact:
+
+```common-lisp
+(with-html-string (:a :href "/about" "About"))
+;; => "<a href=/about>About</a>"
+```
+
+This becomes a problem if you're generating a template whose attribute
+values are placeholders for another system to fill in later — for example,
+HTML embedded in a SQL string that a database's own `format()`-style
+function will substitute into at request time. Spinneret only ever sees the
+placeholder text (e.g. `"%s"`), which typically contains no whitespace, so
+it omits the quotes. The output is valid HTML for the literal placeholder
+string, and silently broken HTML the moment the other system substitutes in
+a value that *does* contain whitespace — with no error anywhere in the
+pipeline to catch it, since Spinneret already finished and handed off a
+syntactically valid document as far as it knew.
+
+`*always-quote*` exists for exactly this case:
+
+```common-lisp
+(setf *always-quote* t)
+```
+
+quotes every attribute value regardless of content. Two things about it are
+easy to get wrong the first time:
+
+- **It has to be set with `setf`, before the code that uses it is
+  compiled — not `let` around the call site.** Spinneret decides whether to
+  quote a given attribute value at macroexpansion time, so a dynamic
+  binding in effect only at *runtime* has no effect on already-compiled
+  tag forms:
+  ```common-lisp
+  ;; Does NOT work if TEMPLATE was compiled with *always-quote* unbound:
+  (let ((*always-quote* t))
+    (template))
+
+  ;; Works, evaluated before TEMPLATE is compiled:
+  (setf *always-quote* t)
+  (defun template () (with-html-string ...))
+  ```
+- It's a global switch, not scoped to one template. If you only want it for
+  templates like the one above, keep those in their own file or component
+  and set it before loading just that part of your system.
 
 ## Validation
 

--- a/special.lisp
+++ b/special.lisp
@@ -44,5 +44,15 @@ This is always measured from the start of the tag.")
 (declaim (type (member :human :tree) *html-style*))
 
 (defvar *always-quote* nil
-  "Add quotes to all attributes.")
+  "Add quotes to all attributes, regardless of whether their value would
+otherwise be left unquoted per the HTML5 spec. Useful when generating a
+template whose attribute values are placeholders for another system to
+substitute into later — the default unquoted output is only ever checked
+against the literal placeholder text, not whatever ends up there at
+runtime.
+
+Must be set with SETF before the code using it is compiled, not bound
+with LET around the call site: whether to quote a given attribute is
+decided at macroexpansion time, so a dynamic binding in effect only when
+the already-compiled code runs has no effect.")
 (declaim (type boolean *always-quote*))


### PR DESCRIPTION
Type: documentation
Tracking issue: none filed
Breaking change: no
Regression test: none — no behavior changes; verified manually by
reloading an edited checkout via asdf:load-system and confirming both
the docstring and *always-quote* itself behave as described

An attribute value that's a placeholder for another system to
substitute into later (e.g. HTML embedded in a SQL string, filled in
by a database's own format() at request time) is left unquoted if the
placeholder text itself contains no whitespace, since Spinneret
decides whether to quote at compile time. Output is valid HTML for the
placeholder and silently broken HTML once real, whitespace-containing
data lands there at runtime, with no error anywhere in the pipeline.

*always-quote* already fixes this, but two things about it aren't
documented anywhere:

- It must be set with SETF before the code using it is compiled. A LET
  around the call site is a silent no-op, since the quoting decision
  is made at macroexpansion time, not when the compiled tag form runs.
- It isn't mentioned in the README at all.

Add an "Attribute quoting" section to README.md covering both points,
and expand the *always-quote* docstring in special.lisp with the same
information. No code paths change.

Context: found while building
https://github.com/denzuko/todo-app-deploy (FINDINGS.md has the full
writeup this is extracted from).